### PR TITLE
fix(server): not share global serverMux instance

### DIFF
--- a/options.go
+++ b/options.go
@@ -51,7 +51,7 @@ func defaultConfig() *config {
 		enableGoCollector:  false,
 		runtimeMetricRules: []collectors.GoRuntimeMetricsRule{},
 		registry:           prom.NewRegistry(),
-		serveMux:           http.DefaultServeMux,
+		serveMux:           http.NewServeMux(),
 		disableServer:      false,
 	}
 }


### PR DESCRIPTION
[The issue](https://github.com/kitex-contrib/monitor-prometheus/issues/14) that multiple clients registered repeatedly would panic was fixed

Notes: For different clients, avoid using the same port to expose Prometheus metrics